### PR TITLE
Fixes absolute file paths in favor of relative file paths

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
 
     <!-- CSS Stylesheet -->
     <link rel="stylesheet"
-        href="/Users/noble/Documents/Web Developer/Portfolio/Noblelivingco Website/styles/css/app.css">
+        href="styles/css/app.css">
 
     <!-- SASS Stylesheet -->
     <link rel="stylesheet" href="main.scss">

--- a/styles/css/app.css
+++ b/styles/css/app.css
@@ -87,7 +87,7 @@ h4 {
 .navbar .navbar-brand .logo {
     height: 150px;
     width: 150px;
-    
+
 }
 
 .navbar .nav-item {
@@ -99,7 +99,7 @@ h4 {
     padding-right: 6px;
 }
 
-.navbar-nav > li:last-of-type { 
+.navbar-nav > li:last-of-type {
     border-right: none;
 }
 
@@ -109,7 +109,7 @@ h4 {
     font-size: 1.5em;
     font-weight: 600;
     z-index: 3;
-    background: no-repeat center/100% url("/Users/noble/Documents/Web Developer/Portfolio/Noblelivingco Website/images/stock/pink canvas.png");
+    background: no-repeat center/100% url("images/stock/pink canvas.png");
 }
 
 .label-icon {
@@ -131,8 +131,8 @@ h4 {
     height: 40em;
     display: flex;
     align-items: center;
-    justify-content: center;     
-    background: no-repeat center/100% url("/Users/noble/Documents/Web Developer/Portfolio/Noblelivingco Website/images/stock/Women_Laughing_Stock_1.jpg");
+    justify-content: center;
+    background: no-repeat center/100% url("images/stock/Women_Laughing_Stock_1.jpg");
     z-index: -1;
 }
 
@@ -174,7 +174,7 @@ h4 {
     background-color: black;
     height: 2px;
 }
-    
+
 #header-cta {
     display: flex;
     justify-content: center;
@@ -229,7 +229,7 @@ h4 {
 }
 
 #third-section-b h4 {
-    padding-top: 2rem; 
+    padding-top: 2rem;
     padding-bottom: 2rem;
 }
 


### PR DESCRIPTION
Take a look at these three changes, note that before they were pointing to a path on your computer

`/Users/noble/Documents/Web Developer/Portfolio/Noblelivingco Website/styles/css/app.css`

but that's not going to work on my computer (or anyone else's) but I'm quite sure you know about absolute vs. relative file paths because every other path _is_ relative, so I imagine these are just a couple of oversights.

But it's a good chance to go over these things because it's ultra important to always be thinking about how everyone else but you is going to be viewing your work. So, as a refresher:

**Absolute** paths (and they can be either URLs or file paths) begin with either a protocol (e.g. `https://`) or a directory structure (e.g. `/Users/johndoe/my/local/dev/path`) and they're not very adaptable.

*However* relative paths can also begin with a `/` which in turn make them absolute as per the domain itself.

So if we have a website `example.com` and the HTML to include a stylesheet looks like this:

<link rel="stylesheet" href="/styles/css/app.css">

but we're viewing `https://example.com/folder/sub/page/about.html`

The browser is going to look for a stylesheet at `https://example.com/styles/css/app.css`

But the other end of that stick is if we are using a _relative_ path in the HTML when viewing 

`https://example.com/folder/sub/page/about.html`

and the CSS is included like this:

`<link rel="stylesheet" href="styles/css/app.css">` (note the lack of a leading slash)

The browser will look for `https://example.com/folder/sub/page/styles/css/app.css`

That can be both beneficial and hurtful depending on your goals. As you get more into server side development you'll be able to specify an absolute URL for all assets like CSS, images, and JavaScript because the server is going to know its own URL, but for the time being you'll need to keep in mind those relative paths when referencing all assets.